### PR TITLE
Fixed unauthorized error

### DIFF
--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -10,7 +10,7 @@ const config = require('./config/config.js');
 exports.authenticateUser = async (req, res, next) => {
   const token = req.header('x-auth-token');
   if (!token) {
-    return errors.makeForbiddenError(res, 'No auth token provided');
+    return errors.makeUnauthorizedError(res, 'No auth token provided');
   }
 
 
@@ -36,7 +36,7 @@ exports.authenticateUser = async (req, res, next) => {
 
     if (!body.success) {
       // We are not authenticated
-      return errors.makeForbiddenError(res, 'User is not authenticated.');
+      return errors.makeUnauthorizedError(res, 'User is not authenticated.');
     }
 
     if (!req.user) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5060,7 +5060,7 @@
       }
     },
     "oms-common-nodejs": {
-      "version": "git+https://git@github.com/AEGEE/oms-common-nodejs.git#bd4613c31e9ef458b4db9b021b1d7465dc4cb525",
+      "version": "git+https://git@github.com/AEGEE/oms-common-nodejs.git#648f6940967048aae18aed918a8ccd43892d23e2",
       "requires": {
         "request": "2.87.0",
         "request-promise-native": "1.0.5"

--- a/test/api/test-api-requests.js
+++ b/test/api/test-api-requests.js
@@ -22,7 +22,7 @@ describe('API requests', () => {
     chai.request(server)
       .get('/getUser')
       .end((err, res) => {
-        expect(res).to.have.status(403);
+        expect(res).to.have.status(401);
         expect(res.body.success).to.be.false;
 
         done();
@@ -38,7 +38,7 @@ describe('API requests', () => {
       .get('/getUser')
       .set('X-Auth-Token', 'blablabla')
       .end((err, res) => {
-        expect(res).to.have.status(403);
+        expect(res).to.have.status(401);
         expect(res).to.be.json;
         expect(res).to.be.a('object');
         expect(res.body.success).to.be.false;
@@ -146,7 +146,7 @@ describe('API requests', () => {
       .get('/getUser')
       .set('X-Auth-Token', 'blablabla')
       .end((err, res) => {
-        expect(res).to.have.status(403);
+        expect(res).to.have.status(401);
         expect(res).to.be.json;
         expect(res).to.be.a('object');
         expect(res.body.success).to.be.false;


### PR DESCRIPTION
Return 401 instead of 403 on unsuccessful core response, allowing the frontend to understand that we need to redo the request (instead of showing the error).