### PR TITLE
feat: standardise passwords; improve deployability

### DIFF
--- a/config/index.js.example
+++ b/config/index.js.example
@@ -7,7 +7,7 @@ const config = {
             host: process.env.DB_HOST || 'postgres-oms-events',
             port: parseInt(process.env.DB_PORT, 10) || 5432,
             username: process.env.USERNAME || 'postgres',
-            password: process.env.PASSWORD || 'postgres',
+            password: process.env.PASSWORD || '5ecr3t',
             database: process.env.DB_DATABASE || 'events'
         },
         core: {

--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,6 @@
+PATH_OMS_EVENTS=./
+BASE_URL=localhost.test
+PW_POSTGRES=postgres 
+
+#TODO: this file will be copied and some (3) variables 
+#injected by the top-level .env file: BASE_URL, NODE_ENV, PW_POSTGRES

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,15 +3,18 @@ version: '3.2'
 ### mongodb Container #######################################
 services:
     postgres-oms-events:
+        restart: always
         image: postgres:10
         volumes:
             - postgres-events:/var/lib/postgresql/data
         expose:
-            - "5432"
+            - 5432
         environment:
             POSTGRES_USER: postgres
-            POSTGRES_PASSWORD: postgres
+            POSTGRES_PASSWORD: ${PW_POSTGRES}
+
     oms-events:
+        restart: on-failure
         build:
             context: ./$PATH_OMS_EVENTS/oms-events
             dockerfile: ./Dockerfile.dev
@@ -23,7 +26,7 @@ services:
         links:
             - postgres-oms-events
         expose:
-            - "8084"
+            - 8084
         environment:
             BUGSNAG_KEY: 6f6a7c00507fceca0818c48405dbd2a6
         secrets:
@@ -32,13 +35,9 @@ services:
         labels:
             - "traefik.backend=oms-events"
             - "traefik.port=8084"
-            - "traefik.frontend.rule=HostRegexp:{domain:[a-z0-9.]+};PathPrefix:/services/oms-events/api;PathPrefixStrip:/services/oms-events/api"
+            - "traefik.frontend.rule=PathPrefix:/services/oms-events/api;PathPrefixStrip:/services/oms-events/api"
             - "traefik.frontend.priority=110"
             - "traefik.enable=true"
-            - "registry.categories=(events, 10);(notifications, 10)"
-            - "registry.servicename=oms-events"
-
-
 
 volumes:
     postgres-events:


### PR DESCRIPTION
Changes:

-  The default password is 5ecr3t, as we decided being the default for everything
-    The .env file is used both because it's good practice AND to provide more customisation for the bootstrap of the environment (there's still room for improvement)
-    Add restart policies for containers
-    (WiP) remove HostRegexp as a condition
