### PR TITLE
feat: pipeline pushes on dockerhub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,11 @@ script:
   - npm audit
   - npm test
   - codecov
+
+# after_script:
+#   - sudo docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD}
+#   - sudo docker tag aegee/oms-events aegee/oms-events:${TRAVIS_COMMIT}
+#   - sudo docker push aegee/oms-events:${TRAVIS_COMMIT}
+#   - sudo docker tag aegee/oms-events:${TRAVIS_COMMIT} aegee/oms-events:latest
+#   - sudo docker push aegee/oms-events:latest
+#   #if: tag

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,5 @@
 version: '3.2'
-### OMS STATUTORY     #######################################
-### mongodb Container #######################################
+### OMS EVENTS   #######################################
 services:
     postgres-oms-events:
         restart: always
@@ -18,7 +17,7 @@ services:
         build:
             context: ./$PATH_OMS_EVENTS/oms-events
             dockerfile: ./Dockerfile.dev
-        image: aegee/oms-events:dev
+        image: aegee/oms-events
         volumes:
             - oms-events-media:/usr/app/media
             - ./$PATH_OMS_EVENTS/../:/usr/app/src


### PR DESCRIPTION
Doing like this, the pipeline will tag appropriately and push to dockerhub

This can be merged immediately and won't break anything(ish): before this works, you need to go on travis and put the variables called `DOCKER_USER` and `DOCKER_PASSWORD` (they're on 1password)

But before this actually gets run, you need to change the pipeline's language and make it similar to [nico's](https://github.com/AEGEE/oms-core-elixir/blob/433dba38b9d4b4afeefda1a0a4d09718ed7e941f/.travis.yml): put the `language` as `shell` and use `docker-compose exec` to run tests. Then you can uncomment the last piece and it goes smooth