### PR TITLE
impr: docker files are the docker way

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         volumes:
             - postgres-events:/var/lib/postgresql/data
         expose:
-            - 5432
+            - "5432"
         environment:
             POSTGRES_USER: postgres
             POSTGRES_PASSWORD: ${PW_POSTGRES}
@@ -16,9 +16,9 @@ services:
     oms-events:
         restart: on-failure
         build:
-            context: ./$PATH_OMS_EVENTS/oms-events
-            dockerfile: ./Dockerfile.dev
-        image: aegee/oms-events:dev
+            context: ./$PATH_OMS_EVENTS/..
+            dockerfile: ./docker/oms-events/Dockerfile.dev
+            image: aegee/oms-events:dev
         volumes:
             - oms-events-media:/usr/app/media
             - ./$PATH_OMS_EVENTS/../:/usr/app/src
@@ -26,7 +26,7 @@ services:
         links:
             - postgres-oms-events
         expose:
-            - 8084
+            - "8084"
         environment:
             BUGSNAG_KEY: 6f6a7c00507fceca0818c48405dbd2a6
         secrets:

--- a/docker/oms-events/Dockerfile
+++ b/docker/oms-events/Dockerfile
@@ -16,10 +16,8 @@ USER node
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH="/home/node/.npm-global/bin:${PATH}"
 
-RUN npm install -g --loglevel warn nodemon \
-     && npm cache clean --force \
-     && npm install --loglevel warn
+RUN npm install --loglevel warn 
 
-CMD sh /usr/app/scripts/bootstrap.sh && nodemon -e "js,json" lib/run.js
+CMD sh /usr/app/scripts/bootstrap.sh && npm start
 
 EXPOSE 8084

--- a/docker/oms-events/bootstrap.sh
+++ b/docker/oms-events/bootstrap.sh
@@ -5,8 +5,6 @@ then
   cp config/index.js.example config/index.js
 fi
 
-echo "Installing packages..."
-npm install --loglevel warn
 echo "Creating database..."
 npm run db:create
 echo "Migrating database..."

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "scripts": {
+    "start": "node server.js",
     "test": "NODE_ENV=test npm run db:setup && jest test/api/*.js --runInBand --forceExit",
     "lint": "node_modules/.bin/eslint .",
     "db:create": "sequelize db:create",
@@ -35,7 +36,7 @@
     "type": "git",
     "url": "git+https://github.com/AEGEE/oms-events.git"
   },
-  "author": "Nico Westerbeck",
+  "author": "Nico Westerbeck, Sergey Peshkov",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/AEGEE/oms-events/issues"


### PR DESCRIPTION
Just like https://github.com/AEGEE/oms-discounts/pull/2

I made some modifications:

1) Add `npm start` script
2) Dockerfile is production-ready and does not use nodemon but the above `npm start`
3) both Dockerfile and Dockerfile.dev copy the files necessary for the working and run `npm install` there. `bootstrap.sh` only makes the config file and db stuff (which we can't have at build time, at least the db stuff)

Please test in local then merge