### PR TITLE
Added nginx container for static images

### DIFF
--- a/config/index.js.example
+++ b/config/index.js.example
@@ -23,8 +23,7 @@ const config = {
             level: process.env.LOGLEVEL || 'debug'
         },
         bugsnagKey: process.env.BUGSNAG_KEY || '',
-        media_dir: '/usr/app/media',
-        media_url: '/frontend/media',
+        media_dir: '/usr/app/media'
     },
     development: {
 
@@ -55,7 +54,7 @@ const env = process.env.NODE_ENV;
 // If both 'default' and environment fields are missing, than there's no config
 // and we throw an error.
 if (!config[env] && !config.default) {
-    throw new Error(`Both 'default' and '${process.env.NODE_ENV}' are not set in lib/config.json; \
+    throw new Error(`Both 'default' and '${process.env.NODE_ENV}' are not set in config/index.js; \
 cannot run without config.`);
 }
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -4,8 +4,14 @@ services:
     oms-events:
         build:
             context: ./${PATH_OMS_EVENTS}/..
-            dockerfile: ./docker/oms-events/Dockerfile.dev
+            dockerfile: ./docker/oms-events/Dockerfile
         image: aegee/oms-events:dev
         volumes:
             - /usr/app/src/node_modules
             - ./${PATH_OMS_EVENTS}/../:/usr/app/src
+
+    oms-events-static:
+        build:
+            context: ./${PATH_OMS_EVENTS}/..
+            dockerfile: ./docker/oms-events-static/Dockerfile
+        image: aegee/oms-events-static:dev

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -41,6 +41,27 @@ services:
             - "traefik.frontend.priority=110"
             - "traefik.enable=true"
 
+    oms-events-static:
+        restart: on-failure
+        image: aegee/oms-events-static:latest
+        volumes:
+            - oms-events-media:/usr/app/media
+            - shared:/usr/app/shared:ro
+        expose:
+            - "80"
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:80/healthcheck"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
+            start_period: 40s
+        labels:
+            - "traefik.backend=oms-events-static"
+            - "traefik.port=80"
+            - "traefik.frontend.rule=PathPrefix:/services/oms-events/media;PathPrefixStrip:/services/oms-events/media"
+            - "traefik.frontend.priority=110"
+            - "traefik.enable=true"
+
 volumes:
     postgres-oms-events:
         driver: local

--- a/docker/oms-events-static/Dockerfile
+++ b/docker/oms-events-static/Dockerfile
@@ -1,0 +1,21 @@
+FROM nginx:1.17.0-alpine
+
+RUN mkdir -p /usr/app/src
+WORKDIR /usr/app/src
+
+RUN apk add curl
+
+RUN adduser -D -H -u 1000 -s /bin/bash www-data -G www-data
+
+COPY ./docker/oms-events-static/status.json /usr/app/status.json
+COPY ./docker/oms-events-static/nginx.conf /etc/nginx/nginx.conf
+COPY ./docker/oms-events-static/sites/default.conf /etc/nginx/sites-available/default.conf
+
+# it has some default settings there which result in displaying
+# the default nginx page, which is not what we need
+RUN rm -rf /etc/nginx/conf.d
+RUN chmod 755 -R /usr/app/
+
+WORKDIR /usr/app/media
+EXPOSE 80
+CMD ["nginx"]

--- a/docker/oms-events-static/sites/default.conf
+++ b/docker/oms-events-static/sites/default.conf
@@ -1,0 +1,22 @@
+server {
+    listen 80;
+    server_name oms-frontend;
+    root "/usr/app/media";
+
+    charset utf-8;
+
+    location /healthcheck {
+        alias /usr/app/status.json;
+        add_header "Content-Type" "application/json";
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log /dev/stdout;
+    error_log stderr;
+
+    sendfile off;
+
+    client_max_body_size 100m;
+}

--- a/docker/oms-events-static/status.json
+++ b/docker/oms-events-static/status.json
@@ -1,0 +1,3 @@
+{
+    "success": true
+}

--- a/docker/oms-events/Dockerfile
+++ b/docker/oms-events/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:12
 
 RUN mkdir -p /usr/app/src \
-	&& mkdir -p /usr/app/media \
+	&& mkdir -p /usr/app/media/headimages \
 	&& mkdir -p /usr/app/scripts
 
 COPY ./docker/oms-events/bootstrap.sh /usr/app/scripts/bootstrap.sh

--- a/lib/server.js
+++ b/lib/server.js
@@ -17,7 +17,6 @@ const config = require('../config');
 
 const EventsRouter = router({ mergeParams: true });
 const GeneralRouter = router({ mergeParams: true });
-const ImagesRouter = router({ mergeParams: true });
 
 /* istanbul ignore next */
 if (process.env.NODE_ENV !== 'test') {
@@ -37,8 +36,6 @@ process.on('unhandledRejection', (err) => {
         bugsnag.notify(err);
     }
 });
-
-ImagesRouter.use(express.static(config.media_dir)); // Serving images.
 
 GeneralRouter.get('/healthcheck', middlewares.healthcheck);
 GeneralRouter.get('/metrics', metrics.getMetrics);
@@ -84,7 +81,6 @@ EventsRouter.post('/bodies', events.addLocal);
 EventsRouter.delete('/bodies/:body_id', events.deleteLocal);
 
 server.use(endpointsMetrics.addEndpointMetrics);
-server.use(config.media_url, ImagesRouter);
 server.use('/', GeneralRouter);
 server.use('/single/:event_id', EventsRouter);
 


### PR DESCRIPTION
Now static images (like the ones uploaded as events covers) are served not by node, but by nginx. Added the new nginx container for static files and only them and healthcheck for it.
Using nginx is considered as a good practice for production, I've consulted it there: https://stackoverflow.com/questions/44796056/whats-the-better-approach-serving-static-files-with-express-or-nginx

@linuxbandit requesting your review here because it's adding another container and I'll most likely do the same for statutory as well.