### PR TITLE
fix(logging): write only specific fields for user logging

### DIFF
--- a/lib/morgan.js
+++ b/lib/morgan.js
@@ -1,15 +1,24 @@
 const morgan = require('morgan');
+const _ = require('lodash');
 
 const log = require('./logger');
 
 module.exports = morgan((tokens, req, res) => {
+    const user = req.user
+        ? _.pick(req.user, ['id', 'username', 'first_name', 'last_name', 'email'])
+        : undefined;
+
+    const body = _.isEmpty(req.body)
+        ? undefined
+        : req.body;
+
     log.info({
         method: tokens.method(req, res),
         url: tokens.url(req, res),
         status: tokens.status(req, res),
         length: tokens.res(req, res, 'content-length'),
         'response-time': tokens['response-time'](req, res),
-        user: req.user,
-        body: req.body
+        user,
+        body
     }, 'Request processed');
 });

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "express-query-boolean": "^2.0.0",
     "faker": "^4.1.0",
     "file-type": "^14.5.0",
+    "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "morgan": "^1.9.1",
     "multer": "^1.4.2",


### PR DESCRIPTION
for now, we are writing the whole user object (with bodies, circles, join requests etc.) when logging requests, that's too much. this is the copypaste of the core thing I have (which has it right from the start), which logs only specific fields, also I'll add it to other services later.